### PR TITLE
Make a new copy of the GC class at every poll

### DIFF
--- a/src/main.rb
+++ b/src/main.rb
@@ -250,17 +250,10 @@ class TrowGarbageCollector
 
     puts_df_data
   end
-
-  def main_loop
-    OptionParser.new { |opts|
-    }.parse!
-
-    @log.info("Starting main_loop with #{POLL_INTERVAL}s polling interval.")
-    loop do
-      garbage_collect(dry_run: false) # FIXME
-      sleep(POLL_INTERVAL)
-    end
-  end
 end
 
-TrowGarbageCollector.new.main_loop if $PROGRAM_NAME == __FILE__
+loop do
+  puts "Starting main_loop with #{TrowGarbageCollector::POLL_INTERVAL}s polling interval."
+  TrowGarbageCollector.new.garbage_collect(dry_run: false)
+  sleep(TrowGarbageCollector::POLL_INTERVAL)
+end if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
**Issue**

When blobs are garbage collected and removed, the `TrowGarbageCollector` class will attempt to remove the same blobs during the next poll interval, causing it to crash and restart the pod.

First attempt to GC. In this example:
```
Blobs: 57
Total size: 3163284635 bytes
Manifests: 3
Orphaned blobs: 9
Orphaned blob total size: 6064493 bytes
I, [2022-03-16T23:26:55.839996 #1]  INFO -- : Deleting orphaned blobs...
```

At the next poll interval, the GC will attempt to delete the same blobs:

```
Blobs: 57
Total size: 3163284635 bytes
Manifests: 3
Orphaned blobs: 9
Orphaned blob total size: 6064493 bytes
I, [2022-03-16T23:28:15.800096 #1]  INFO -- : Deleting orphaned blobs...
/opt/opschain/main.rb:225:in `delete_orphaned_blobs': Error: pid 331 exit 123 (RuntimeError)
	from /opt/opschain/main.rb:249:in `garbage_collect'
	from /opt/opschain/main.rb:260:in `block in main_loop'
	from /opt/opschain/main.rb:259:in `loop'
	from /opt/opschain/main.rb:259:in `main_loop'
	from /opt/opschain/main.rb:266:in `<main>'
```

**Solution**

Make sure that all the instance variables are cleared when attempting to GC in the next poll interval.