### PR TITLE
Bug fixes

### DIFF
--- a/src/main.rb
+++ b/src/main.rb
@@ -92,7 +92,7 @@ class TrowGarbageCollector
   end
 
   def fetch_file_sizes
-    result = trow_exec("/bin/bash", "-c", "find /data/ -type f -print0 | xargs -0 -n 1 stat -c '%s %Y %n'")
+    result = trow_exec("/bin/bash", "-c", "find /data/ -type f -print0 | xargs --no-run-if-empty -0 -n 1 stat -c '%s %Y %n'")
     raise "Error: #{result.status}" unless result.status.success?
 
     result.stdout.strip.split("\n").each do |line|

--- a/src/main.rb
+++ b/src/main.rb
@@ -116,7 +116,7 @@ class TrowGarbageCollector
     @_manifest_tmpdir = File.join("/dev/shm", SecureRandom.hex)
     FileUtils.mkdir(@_manifest_tmpdir)
 
-    Open3.pipeline(["kubectl", "exec", "-n", TROW_NAMESPACE, TROW_POD, "--", "/bin/bash", "-c", "find /data/manifests/ -type f -print0 | xargs -0 tar -cf -"],
+    Open3.pipeline(["kubectl", "exec", "-n", TROW_NAMESPACE, TROW_POD, "--", "/bin/bash", "-c", "find /data/manifests/ -type f -print0 | xargs --no-run-if-empty -0 tar -cf -"],
       ["tar", "-C", @_manifest_tmpdir, "-xf", "-"])
   end
 


### PR DESCRIPTION
### Issue
The Repository orphaned_blobs method filters @blobs and returns a hash of blobs to remove to the TrowGarbageCollector to delete. If the delete is successful, the Repository class does not remove these blobs from @blobs. This causes subsequent calls to orphaned_blobs to return the same blobs for deletion which in turn causes TrowGarbageCollector to raise an exception when it tries to delete the already removed file.

### Solution
Added a filenames_to_delete method to Repository to yield the file list to TrowGarbageCollector. If the delete returns successfully, the relevant keys are removed from @blobs.

Also added two simple commits to avoid throwing errors when the garbage collector is run against a trow registry with no files in it.